### PR TITLE
Fixes to display spi speed

### DIFF
--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -35,9 +35,9 @@ TFT_CLK_PIN = const(18)
 TFT_RST_PIN = const(33)
 TFT_MISO_PIN = const(19)
 
-def tone(frequency, duration=100, pin=None, volume=1):
-    if pin is None:
-        pin = Pin(SPEAKER_PIN)
+def tone(frequency, duration=100, pin=SPEAKER_PIN, volume=1):
+    # if pin is None:
+    #     pin = Pin(SPEAKER_PIN)
 
     pwm = PWM(pin, duty=volume % 50)
     pwm.freq(frequency)

--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -61,7 +61,7 @@ class ButtonC(DigitalInput):
 
 class Display(object):
 
-    def __init__(self):
+    def __init__(self, spiSpeed=20000000):
         self.tft = self.create()
 
     def __getattr__(self, name):
@@ -82,7 +82,7 @@ class Display(object):
             rst_pin=TFT_RST_PIN,
             backl_pin=TFT_LED_PIN,
             backl_on=1,
-            speed=40000000,
+            speed=spiSpeed,
             invrot=3,
             bgr=True
         )

--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -61,7 +61,7 @@ class ButtonC(DigitalInput):
 
 class Display(object):
 
-    def __init__(self, spiSpeed=20000000):
+    def __init__(self, spiSpeed=26000000):
         self.tft = self.create()
 
     def __getattr__(self, name):

--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -82,7 +82,7 @@ class Display(object):
             rst_pin=TFT_RST_PIN,
             backl_pin=TFT_LED_PIN,
             backl_on=1,
-            speed=2600000,
+            speed=40000000,
             invrot=3,
             bgr=True
         )

--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -36,9 +36,6 @@ TFT_RST_PIN = const(33)
 TFT_MISO_PIN = const(19)
 
 def tone(frequency, duration=100, pin=SPEAKER_PIN, volume=1):
-    # if pin is None:
-    #     pin = Pin(SPEAKER_PIN)
-
     pwm = PWM(pin, duty=volume % 50)
     pwm.freq(frequency)
     time.sleep_ms(duration)
@@ -61,7 +58,8 @@ class ButtonC(DigitalInput):
 
 class Display(object):
 
-    def __init__(self, spiSpeed=26000000):
+    def __init__(self, speed=26000000):
+        self.speed = speed
         self.tft = self.create()
 
     def __getattr__(self, name):
@@ -82,7 +80,7 @@ class Display(object):
             rst_pin=TFT_RST_PIN,
             backl_pin=TFT_LED_PIN,
             backl_on=1,
-            speed=spiSpeed,
+            speed=self.speed,
             invrot=3,
             bgr=True
         )


### PR DESCRIPTION
I made a change to allow the spi speed to be changed when creating an instance of the Display.
I also made the default speed 26MHz (which is the default for the driver) from the 2.6MHz that is set in your code. I am assuming you missed a zero when you wrote this. I have tested my display up to 40MHz with no issues and it makes a massive difference in performance.

One more small change was to get rid of an unneeded 'if' statement in the 'tone' method.
