### PR TITLE
Add m5stack constants and function for configuring SD card reader.

### DIFF
--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -17,6 +17,8 @@ M5Stack specific constants and classes.
 import utime as time
 import display
 import machine
+from uos import sdconfig as uos_sdconfig
+from uos import SDMODE_SPI
 from input import DigitalInput
 from machine import Pin, PWM
 from micropython import const
@@ -25,6 +27,7 @@ from micropython import const
 BUTTON_A_PIN = const(39)
 BUTTON_B_PIN = const(38)
 BUTTON_C_PIN = const(37)
+
 SPEAKER_PIN = const(25)
 
 TFT_LED_PIN = const(32)
@@ -34,6 +37,15 @@ TFT_MOSI_PIN = const(23)
 TFT_CLK_PIN = const(18)
 TFT_RST_PIN = const(33)
 TFT_MISO_PIN = const(19)
+
+SD_MODE = SDMODE_SPI
+SD_CLK = const(18)
+SD_MOSI = const(23)
+SD_MISO = const(19)
+SD_CS = const(4)
+
+def sdconfig(mode=SD_MODE, clk=SD_CLK, mosi=SD_MOSI, miso=SD_MISO, cs=SD_CS):
+        uos_sdconfig(mode, clk, mosi, miso, cs)
 
 def tone(frequency, duration=100, pin=SPEAKER_PIN, volume=1):
     pwm = PWM(pin, duty=volume % 50)
@@ -89,3 +101,4 @@ class Display(object):
         tft.font(tft.FONT_Small, fixedwidth=True)
 
         return tft
+

--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -35,9 +35,9 @@ TFT_CLK_PIN = const(18)
 TFT_RST_PIN = const(33)
 TFT_MISO_PIN = const(19)
 
-def tone(frequency, duration=100, pin=None, volume=1):
-    if pin is None:
-        pin = Pin(SPEAKER_PIN)
+def tone(frequency, duration=100, pin=SPEAKER_PIN, volume=1):
+    # if pin is None:
+    #     pin = Pin(SPEAKER_PIN)
 
     pwm = PWM(pin, duty=volume % 50)
     pwm.freq(frequency)

--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -61,7 +61,7 @@ class ButtonC(DigitalInput):
 
 class Display(object):
 
-    def __init__(self):
+    def __init__(self, spiSpeed=20000000):
         self.tft = self.create()
 
     def __getattr__(self, name):
@@ -82,7 +82,7 @@ class Display(object):
             rst_pin=TFT_RST_PIN,
             backl_pin=TFT_LED_PIN,
             backl_on=1,
-            speed=40000000,
+            speed=spiSpeed,
             invrot=3,
             bgr=True
         )

--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -61,7 +61,7 @@ class ButtonC(DigitalInput):
 
 class Display(object):
 
-    def __init__(self, spiSpeed=20000000):
+    def __init__(self, spiSpeed=26000000):
         self.tft = self.create()
 
     def __getattr__(self, name):

--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -82,7 +82,7 @@ class Display(object):
             rst_pin=TFT_RST_PIN,
             backl_pin=TFT_LED_PIN,
             backl_on=1,
-            speed=2600000,
+            speed=40000000,
             invrot=3,
             bgr=True
         )

--- a/firmware/lib/m5stack.py
+++ b/firmware/lib/m5stack.py
@@ -36,9 +36,6 @@ TFT_RST_PIN = const(33)
 TFT_MISO_PIN = const(19)
 
 def tone(frequency, duration=100, pin=SPEAKER_PIN, volume=1):
-    # if pin is None:
-    #     pin = Pin(SPEAKER_PIN)
-
     pwm = PWM(pin, duty=volume % 50)
     pwm.freq(frequency)
     time.sleep_ms(duration)
@@ -61,7 +58,8 @@ class ButtonC(DigitalInput):
 
 class Display(object):
 
-    def __init__(self, spiSpeed=26000000):
+    def __init__(self, speed=26000000):
+        self.speed = speed
         self.tft = self.create()
 
     def __getattr__(self, name):
@@ -82,7 +80,7 @@ class Display(object):
             rst_pin=TFT_RST_PIN,
             backl_pin=TFT_LED_PIN,
             backl_on=1,
-            speed=spiSpeed,
+            speed=self.speed,
             invrot=3,
             bgr=True
         )


### PR DESCRIPTION
Added the m5stack specific pins as the default for uos.configsd().
The SD card can be configured with m5stack.configsd()
It is then ready to be mounted via the normal method of uos.mountsd().