### PR TITLE
Pin.irq() removed in recent refactor

### DIFF
--- a/firmware/lib/input.py
+++ b/firmware/lib/input.py
@@ -26,8 +26,7 @@ class DigitalInput(object):
         self._current_state = False
         self._previous_state = False
         self._pin = pin
-        self._pin.init(self._pin.IN)
-        self._pin.irq(trigger=trigger, handler=self._callback)
+        self._pin.init(self._pin.IN, trigger=trigger, handler=self._callback)
 
     def _callback(self, pin):
         irq_state = machine.disable_irq()


### PR DESCRIPTION
https://github.com/loboris/MicroPython_ESP32_psRAM_LoBo/commit/a122bff5d8bc0b1a639b6a84407b498114dbef9a

Simple fix is to just move the `trigger` + `handler` args into the `Pin.init()`